### PR TITLE
fix(home): disable phantom scrolling on index page

### DIFF
--- a/assets/css/elements.css
+++ b/assets/css/elements.css
@@ -6,8 +6,15 @@ html {
   scroll-padding-top: calc(var(--font-size) * 7.4);
 }
 
-html.is-signal {
-  scroll-behavior: auto;
+html.is-signal,
+html.is-signal body {
+  height: 100%;
+  min-height: 100%;
+  overflow-y: hidden;
+}
+
+html.is-signal .boundary {
+  display: none;
 }
 
 body {
@@ -17,7 +24,7 @@ body {
   display: flex;
   flex-direction: column;
   font-family: var(--font-family);
-  font-feature-settings: 'liga', 'ss02';
+  font-feature-settings: "liga", "ss02";
   font-size: var(--font-size);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -31,12 +38,10 @@ body {
   text-rendering: optimizeLegibility;
 }
 
-@supports(-webkit-touch-callout: none) {
-
+@supports (-webkit-touch-callout: none) {
   body {
     min-height: -webkit-fill-available;
   }
-
 }
 
 ::selection {
@@ -93,7 +98,7 @@ blockquote > * + * {
 }
 
 blockquote:before {
-  content: '\201C';
+  content: "\201C";
   font-size: 200%;
   font-weight: 300;
   left: 0;
@@ -159,10 +164,8 @@ table th {
   font-size: var(--font-size-xxx-large);
 }
 
-@media(min-width: 64em) and (hover: hover) and (pointer: fine) {
-
+@media (min-width: 64em) and (hover: hover) and (pointer: fine) {
   html {
     scroll-padding-top: 22.2vh;
   }
-
 }


### PR DESCRIPTION
- Scoped overflow-y: hidden to homepage only (via .is-signal)
- Removed useless .boundary spacing
- Verified other pages still scroll normally